### PR TITLE
Fix race conditions in Capture/CaptureWithCGo

### DIFF
--- a/capture_testwrapper.go
+++ b/capture_testwrapper.go
@@ -28,12 +28,16 @@ func testCapture(t *testing.T) {
 }
 
 func testCaptureWithCGo(t *testing.T) {
-	out, err := CaptureWithCGo(func() {
-		fmt.Println("Go")
-		C.printSomething()
-	})
+	out, err := testCaptureWithCGoWrapper()
 	assert.NoError(t, err)
 
 	assert.Contains(t, string(out), "Go")
 	assert.Contains(t, string(out), "C")
+}
+
+func testCaptureWithCGoWrapper() ([]byte, error) {
+	return CaptureWithCGo(func() {
+		fmt.Println("Go")
+		C.printSomething()
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/zimmski/osutil
+
+go 1.17
+
+require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
When run in parallel, the current code can panic
due to "unlock of unlocked mutex".
Specifically, what would happen is:

- Routine1 swaps file descriptors
- Routine2 then swaps FDs again
- Routine1 finishes and tries to restore FDs
- Routine1 errors restoring FDs in the defer,
  causing one of the 'if e != nil, unlock' branches
  to be hit.
- The unconditional 'unlock' call then runs,
  and re-unlocks the mutex, panicing.

Because there were no tests with concurrency,
this bug wasn't detected (it is trivial to reproduce
by adding parallelization, as the test indicates).

While trying to debug and fix this bug (avoiding multiple unlocks),
I realized that the cause of hitting the branch (failure restoring FDs)
indicates a logical problem- because the FDs are global to the process,
it would be very easy to lose/interleave input:

- Routine1 swaps FDs (stdout/err are routine1's copies)
- Routine2 swaps FDs (stdout/err are routine2's copies)
- Routine1's callback runs and writes to routine2's fd copies

To avoid this, I simplified everything and take a mutex on the whole
function (multiple defers run in LIFO).
The downside here is obviously that we have to run the callback
inside of the mutex; however, I am not sure what the option could be.
If code (C or Go) writes to stdout/os.Stdout or err,
it logically must run in isolation.
Avoiding the function-side lock allows concurrent callbacks
but with incorrect results.